### PR TITLE
Add option to specify currentBuildCommand

### DIFF
--- a/packages/esbuildnx/README.md
+++ b/packages/esbuildnx/README.md
@@ -59,7 +59,7 @@ nx esbuild <node-app> --watch
 
 ### Overridden build
 
-If the setup was run with the `--overritde` flag, build your node app as normal within the nx environment.
+If the setup was run with the `--overwrite` flag, build your node app as normal within the nx environment.
 ```shell
 nx build <node-app>
 ```

--- a/packages/esbuildnx/src/generators/setup/schema.d.ts
+++ b/packages/esbuildnx/src/generators/setup/schema.d.ts
@@ -2,4 +2,5 @@ export interface Schema {
   name: string;
   overwrite?: boolean;
   defaultNestExternals?: boolean;
+  currentBuildCommand?: string;
 }

--- a/packages/esbuildnx/src/generators/setup/schema.json
+++ b/packages/esbuildnx/src/generators/setup/schema.json
@@ -23,6 +23,11 @@
       "type": "boolean",
       "default": false,
       "description": "Will fill in necessary externalized packages for a starting NestJS app."
+    },
+    "currentBuildCommand": {
+      "type": "string",
+      "default": "build",
+      "description": "The name of the build target in workspace.json that should be cloned/replaced"
     }
   },
   "required": ["name"]

--- a/packages/esbuildnx/src/generators/setup/setup.ts
+++ b/packages/esbuildnx/src/generators/setup/setup.ts
@@ -15,7 +15,9 @@ import type { BuildOptions } from 'esbuild';
 export async function setupGenerator(host: Tree, options: Schema) {
   const projectConfig = readProjectConfiguration(host, options.name); // Probably needs a try/catch
 
-  const currentBuild = projectConfig?.targets?.[options.currentBuildCommand];
+  const { currentBuildCommand = 'build' } = options;
+
+  const currentBuild = projectConfig?.targets?.[currentBuildCommand];
 
   if (
     !currentBuild ||
@@ -27,7 +29,8 @@ export async function setupGenerator(host: Tree, options: Schema) {
   }
 
   if (options.overwrite) {
-    projectConfig.targets[options.currentBuildCommand].executor = '@anatine/esbuildnx:build';
+    projectConfig.targets[currentBuildCommand].executor =
+      '@anatine/esbuildnx:build';
   } else {
     projectConfig.targets.esbuild = {
       ...currentBuild,

--- a/packages/esbuildnx/src/generators/setup/setup.ts
+++ b/packages/esbuildnx/src/generators/setup/setup.ts
@@ -15,7 +15,7 @@ import type { BuildOptions } from 'esbuild';
 export async function setupGenerator(host: Tree, options: Schema) {
   const projectConfig = readProjectConfiguration(host, options.name); // Probably needs a try/catch
 
-  const currentBuild = projectConfig?.targets?.build;
+  const currentBuild = projectConfig?.targets?.[options.currentBuildCommand];
 
   if (
     !currentBuild ||
@@ -27,7 +27,7 @@ export async function setupGenerator(host: Tree, options: Schema) {
   }
 
   if (options.overwrite) {
-    projectConfig.targets.build.executor = '@anatine/esbuildnx:build';
+    projectConfig.targets[options.currentBuildCommand].executor = '@anatine/esbuildnx:build';
   } else {
     projectConfig.targets.esbuild = {
       ...currentBuild,


### PR DESCRIPTION
In my case, we have a multi-stage build where the node stage is named `build-server`. In that case, I can use --currentBuildCommand=build-server.

Also fix --overwrite flag in readme.