### PR TITLE
Adding outfile property to the response of buildExecutor

### DIFF
--- a/packages/esbuildnx/src/executors/build/build.impl.ts
+++ b/packages/esbuildnx/src/executors/build/build.impl.ts
@@ -16,11 +16,13 @@ import { format } from 'date-fns';
 import { inspect } from 'util';
 import { copyPackages, getPackagesToCopy } from '../../utils/walk-packages';
 import { copyAssets } from '../../utils/assets';
+import { OUTFILE_NAME } from '../../utils/constants';
+import { NodeBuildEvent } from '@nrwl/node/src/executors/build/build.impl';
 
 export function buildExecutor(
   rawOptions: BuildExecutorSchema,
   context: ExecutorContext
-): AsyncIterableIterator<{ success: boolean }> {
+): AsyncIterableIterator<NodeBuildEvent> {
   const { sourceRoot, root } = context.workspace.projects[context.projectName];
 
   if (!sourceRoot) {
@@ -54,6 +56,7 @@ export function buildExecutor(
   );
 
   const outdir = `${options.outputPath}`;
+  const outfile = `${outdir}/${OUTFILE_NAME}`;
 
   const watchDir = `${options.root}/${options.sourceRoot}`;
 
@@ -223,6 +226,7 @@ export function buildExecutor(
           console.log(buildResults.message);
           return {
             success: buildResults?.success && tscResults?.success,
+            outfile,
           };
         })
       )
@@ -260,6 +264,7 @@ export function buildExecutor(
               tscResults?.success &&
               packageCopyResults.success &&
               assetCopyResults.success,
+            outfile,
           };
         }
       )

--- a/packages/esbuildnx/src/utils/constants.ts
+++ b/packages/esbuildnx/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const OUTFILE_NAME = 'main.js'


### PR DESCRIPTION
The @nrwl/node executor require an outfile property to start the app on serve.

By using the NodeBuildEvent from @nrwl/node as the output signature for the buildExecutor we get
the outfile property. The outfile property needs to point to the built main.js file in the output directory of the build.