### PR TITLE
Fix empty string gobbling too much of the file

### DIFF
--- a/packages/esbuild-decorators/src/__tests__/mock-project/app/src/strip-it.ts.test
+++ b/packages/esbuild-decorators/src/__tests__/mock-project/app/src/strip-it.ts.test
@@ -4,6 +4,8 @@ THIS_
 
 SHOULD_['This is a string used as a key']
 
+REALLY_ = ''
+
 /*
  * None of this should catch a @element in a comment.
  */

--- a/packages/esbuild-decorators/src/__tests__/strip-it.spec.ts
+++ b/packages/esbuild-decorators/src/__tests__/strip-it.spec.ts
@@ -9,9 +9,11 @@ describe(`Strip It`, () => {
     );
 
     const result = strip(testFile)
-      .replace(/[:[\]\n]|\s*/g, '')
+      .replace(/[:=[\]\n]|\s*/g, '')
       .replace(/_/g, ' ');
 
-    expect(result).toEqual(`THIS SHOULD ALL BE WHAT'S LEFT OF THE ENTIRE FILE`);
+    expect(result).toEqual(
+      `THIS SHOULD REALLY ALL BE WHAT'S LEFT OF THE ENTIRE FILE`
+    );
   });
 });

--- a/packages/esbuild-decorators/src/lib/strip-it.ts
+++ b/packages/esbuild-decorators/src/lib/strip-it.ts
@@ -53,7 +53,7 @@ class TextBlock extends TextNode {
 
 const constants = {
   ESCAPED_CHAR_REGEX: /^\\./,
-  QUOTED_STRING_REGEX: /^(['"`])((?:\\.|[^\1])+?)(\1)/,
+  QUOTED_STRING_REGEX: /^(['"`])((?:\\.|[^\1])*?)(\1)/,
   NEWLINE_REGEX: /^\r*\n/,
   BLOCK_OPEN_REGEX: /^\/\*\*?(!?)/,
   BLOCK_CLOSE_REGEX: /^\*\/(\n?)/,


### PR DESCRIPTION
`QUOTED_STRING_REGEX` required at least one character between the quotes and will therefore not detect the end of an empty string.

With this PR, there can be zero characters between the quotes.

Example:

```ts
export const foo = ''

@SomeDecorator()
export class Foo {}
```